### PR TITLE
adding two SVGs for visual tests

### DIFF
--- a/svg/circle-mm.svg
+++ b/svg/circle-mm.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 24 0"
+   height="13.546667mm"
+   width="13.546667mm">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-1204.3622)"
+     id="layer1">
+    <circle
+       r="24"
+       cy="1228.3622"
+       cx="24"
+       id="path4138"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  </g>
+</svg>

--- a/svg/shield-multiple-command-parts.svg
+++ b/svg/shield-multiple-command-parts.svg
@@ -1,0 +1,4 @@
+<svg id="shields" xmlns="http://www.w3.org/2000/svg" width="36" height="40" viewBox="0 0 36 40">
+  <title>shield</title>
+  <path d="M18,36a47.84,47.84,0,0,0,14-2c3-.92,4-4,4-7V22C36,11,28,3,18,0,8,3,0,11,0,22v5c0,3,1,6.05,4,7A47.84,47.84,0,0,0,18,36Z"/>
+</svg>


### PR DESCRIPTION
### What changed?

Adding two svgs to `svg/` for extra visual tests
- `circle-mm.svg`
- `shield-multiple-command-parts.svg`

cc/ @springmeyer @jakepruitt 
